### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "bluebird": "^3.4.0",
     "incident": "^1.0.6",
     "lodash": "^4.12.0",
-    "node-uuid": "^1.4.7",
-    "palantiri-interfaces": "^0.3.4"
+    "palantiri-interfaces": "^0.3.4",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/src/meta-discussion.ts
+++ b/src/meta-discussion.ts
@@ -2,7 +2,7 @@ import * as Bluebird from "bluebird";
 import * as palantiri from "palantiri-interfaces";
 import * as _ from "lodash";
 import {Incident} from "incident";
-import {v4 as uuid} from "node-uuid";
+import {v4 as uuid} from "uuid";
 import {EventEmitter} from "events";
 
 import {ContactAccountInterface} from "./interfaces/contact-account";

--- a/src/meta-message.ts
+++ b/src/meta-message.ts
@@ -2,7 +2,7 @@ import MessageInterface from "./interfaces/message";
 import * as Bluebird from "bluebird";
 import {Incident} from "incident";
 import * as palantiri from "palantiri-interfaces";
-import {v4 as uuid} from "node-uuid";
+import {v4 as uuid} from "uuid";
 
 /**
  * TODO: doc.


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.